### PR TITLE
Add support for Sidekiq 3.0

### DIFF
--- a/lib/newrelic_sidekiq_agent.rb
+++ b/lib/newrelic_sidekiq_agent.rb
@@ -3,6 +3,7 @@
 #
 require "newrelic_plugin"
 require "sidekiq"
+require "sidekiq/api"
 
 module SidekiqAgent
   class Agent < NewRelic::Plugin::Agent::Base


### PR DESCRIPTION
As stated in https://github.com/mperham/sidekiq/blob/master/3.0-Upgrade.md you now have to require `sidekiq/api` explicitly.

Apart from that I didn't find other incompatibilities in the list nor in https://github.com/mperham/sidekiq/blob/master/4.0-Upgrade.md too.
